### PR TITLE
Added option to add popup in a specific view

### DIFF
--- a/Source/UIViewController+STZPopupView.swift
+++ b/Source/UIViewController+STZPopupView.swift
@@ -16,6 +16,7 @@ private var configAssociationKey: UInt8 = 0
 /**
 *  UIViewController + STZPopupView
 */
+
 extension UIViewController {
     
     // MARK: - Property

--- a/Source/UIViewController+STZPopupView.swift
+++ b/Source/UIViewController+STZPopupView.swift
@@ -67,29 +67,29 @@ extension UIViewController {
     - parameter popupView: Popup view
     - parameter config:    Config (Option)
     */
-    public func presentPopupView(popupView: UIView, config: STZPopupViewConfig = STZPopupViewConfig()) {
+    public func presentPopupView(popupView: UIView, inView: UIView, config: STZPopupViewConfig = STZPopupViewConfig()) {
 
         if self.containerView != nil {
             return
         }
         
-        let containerView = UIView(frame: targetView.bounds)
+        let containerView = UIView(frame: inView.bounds)
         
-        let overlayView = UIView(frame: targetView.bounds)
+        let overlayView = UIView(frame: inView.bounds)
         overlayView.backgroundColor = config.overlayColor
         containerView.addSubview(overlayView)
         
-        let dismissButton = UIButton(frame: targetView.bounds)
+        let dismissButton = UIButton(frame: inView.bounds)
         containerView.addSubview(dismissButton)
         if config.dismissTouchBackground {
             dismissButton.addTarget(self, action: Selector("dismissPopupView"), forControlEvents: UIControlEvents.TouchUpInside)
         }
         
-        popupView.center = CGPointMake(targetView.frame.size.width / 2, targetView.frame.size.height / 2)
+        popupView.center = CGPointMake(inView.frame.size.width / 2, inView.frame.size.height / 2)
         popupView.layer.cornerRadius = config.cornerRadius
         containerView.addSubview(popupView)
         
-        targetView.addSubview(containerView)
+        inView.addSubview(containerView)
         
         self.containerView = containerView
         self.popupView = popupView


### PR DESCRIPTION
call popup by 
presentPopupView(popup, inView: self.view, config: configs)
if calling from a view controller where you want to show it
// config is optional

or 
presentPopupView(popup, inView: mySpecialSuperAwesomeView, config: configs)

This is very useful when using containerViews, TabBars and NavigationBar based apps
Previously when calling from a containerView / tabBar / NavigationBar based app, the popup will takeup the entire screen.
and cover up the tabBar and navigationBar
