### PR TITLE
Bug fix when device changes its orientation

### DIFF
--- a/Source/UIViewController+STZPopupView.swift
+++ b/Source/UIViewController+STZPopupView.swift
@@ -74,8 +74,9 @@ extension UIViewController {
         }
         
         let containerView = UIView(frame: targetView.bounds)
-        
+        containerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         let overlayView = UIView(frame: targetView.bounds)
+        overlayView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         overlayView.backgroundColor = config.overlayColor
         containerView.addSubview(overlayView)
         
@@ -85,7 +86,11 @@ extension UIViewController {
             dismissButton.addTarget(self, action: #selector(dismissPopupView), for: UIControlEvents.touchUpInside)
         }
         
-        popupView.center = CGPoint(x: targetView.frame.size.width / 2, y: targetView.frame.size.height / 2)
+        popupView.center = CGPoint(x: targetView.bounds.midX, y: targetView.bounds.midY)
+        popupView.autoresizingMask = [.flexibleLeftMargin,
+                                      .flexibleTopMargin,
+                                      .flexibleRightMargin,
+                                      .flexibleBottomMargin]
         popupView.layer.cornerRadius = config.cornerRadius
         containerView.addSubview(popupView)
         

--- a/Source/UIViewController+STZPopupView.swift
+++ b/Source/UIViewController+STZPopupView.swift
@@ -81,6 +81,7 @@ extension UIViewController {
         containerView.addSubview(overlayView)
         
         let dismissButton = UIButton(frame: targetView.bounds)
+        dismissButton.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         containerView.addSubview(dismissButton)
         if config.dismissTouchBackground {
             dismissButton.addTarget(self, action: #selector(dismissPopupView), for: UIControlEvents.touchUpInside)


### PR DESCRIPTION
When landscape and portrait is enabled, the STZPopupView doesn't automatically adjust its constraints.